### PR TITLE
Recognize popular "webpack.config.parts.{js,ts}"

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -866,6 +866,8 @@
 		"webpack.config.base.babel.ts": "_f_webpack",
 		"webpack.config.staging.babel.js": "_f_webpack",
 		"webpack.config.staging.babel.ts": "_f_webpack",
+		"webpack.config.parts.js": "_f_webpack",
+		"webpack.config.parts.ts": "_f_webpack",
 		"webpack.config.coffee": "_f_webpack",
 		"webpack.config.test.js": "_f_webpack",
 		"webpack.config.test.ts": "_f_webpack",


### PR DESCRIPTION
With the rising popularity (and official recommendation) of webpack config structuring through webpack-merge, a store of reusable config parts named `webpack.config.parts.js` (or `.ts`) is getting more and more popular. Having the webpack icon for it would be awesome.