### PR TITLE
added .postcssrc extension

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -673,6 +673,7 @@
 		"merlin": "_f_ocaml",
 		"pdf": "_f_pdf",
 		"postcss": "_f_postcss",
+		"postcssrc": "_f_postcss",
 		"pcss": "_f_postcss",
 		"perl": "_f_perl",
 		"pl": "_f_perl",


### PR DESCRIPTION
From the Vue.js documentation (https://vue-loader.vuejs.org/en/features/postcss.html)

> vue-loader supports auto-loading the same PostCss config files supported by postcss-loader:
> 
> postcss.config.js
> .postcssrc
> postcss field in package.json