### PR TITLE
Add postcss config file names (postcss.config.js, postcss.config.json)

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -698,6 +698,8 @@
 		"pdf": "_f_pdf",
 		"postcss": "_f_postcss",
 		"postcssrc": "_f_postcss",
+		"postcss.config.js": "_f_postcss",
+		"postcss.config.json": "_f_postcss",
 		"pcss": "_f_postcss",
 		"perl": "_f_perl",
 		"pl": "_f_perl",


### PR DESCRIPTION
As said in PR #105:

> vue-loader supports auto-loading the same PostCss config files supported by postcss-loader:
> 
> postcss.config.js
> .postcssrc
> postcss field in package.json
