### PR TITLE
fix: .test.mjs support

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -872,6 +872,7 @@
 		"swift": "_f_swift",
 		"test.js": "_f_tests",
 		"test.jsx": "_f_tests",
+		"test.mjs": "_f_tests",
 		"test.ts": "_f_tests",
 		"test.tsx": "_f_tests",
 		"spec.js": "_f_tests",


### PR DESCRIPTION
ESM files have the `.mjs` extension as documented in the [nodejs docs](https://nodejs.org/api/esm.html) and writing tests with this extension will not show up the test icon:

![image](https://user-images.githubusercontent.com/11404065/92326630-de416180-f053-11ea-9c26-6d3ec40c10d5.png)
