### PR TITLE
Add steepfile to icons.json#fileNames

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -1235,6 +1235,7 @@
 		"paket.dependencies": "_f_paket",
 		"paket.lock": "_f_paket",
 		"paket.local": "_f_paket",
+		"steepfile": "_f_ruby",
 		"gemfile": "_f_ruby",
 		"gemfile.lock": "_f_ruby",
 		"vscodeignore.json": "_f_visualstudiocode",


### PR DESCRIPTION
I implemented that the icon of Steepfile, ruby type annotation file, is displayed. Please see https://github.com/EmmanuelBeziat/vscode-great-icons/issues/221 for details.

