### PR TITLE
fix: VSCode navigation to repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/EmmanuelBeziat/vscode-great-icons.git"
+		"url": "https://github.com/EmmanuelBeziat/vscode-great-icons.git"
 	},
 	"author": {
 		"email": "contact@emmanuelbeziat.com",


### PR DESCRIPTION
Hoi! ^w^,

Navigation to the source repository from your extension page within VSCode is currently broken :(

Clicking the "Repository" hyperlink on the right-hand sidebar currently shows an error and does not navigate

![image](https://user-images.githubusercontent.com/24364012/156267540-dc94ea93-205e-47be-a2f7-ee6546afd26e.png)

Since Microsoft uses the `repository.url` string to navigate to the URL, this PR fixes that so that navigation does work, in line with [similar projects](https://github.com/PKief/vscode-material-icon-theme/blob/f425c965210cdb471b4fdb792e0cecd5a4285a27/package.json#L35)