### PR TITLE
feat: Add support for .env.dev files. 

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -271,7 +271,7 @@
 		"_f_matlab-alt": {
 			"iconPath": "./icons/matlab-red.svg"
 		},
-    	"_f_mdx": {
+		"_f_mdx": {
 			"iconPath": "./icons/mdx.svg"
 		},
 		"_f_mjml": {
@@ -420,7 +420,7 @@
 		},
 		"_f_vitejs": {
 			"iconPath": "./icons/vitejs.svg"
-    },
+		},
 		"_f_snowpackjs": {
 			"iconPath": "./icons/snowpackjs.svg"
 		},
@@ -930,6 +930,7 @@
 		"env.test": "_f_dotenv",
 		"env.staging": "_f_dotenv",
 		"env.staging.example": "_f_dotenv",
+		"env.dev": "_f_dotenv",
 		"ini": "_f_settings",
 		"conf": "_f_settings",
 		"load": "_f_settings",


### PR DESCRIPTION
Added icon support for `.env.dev` files. Hope this can be added. Please let me know if any more changes are needed. Never worked with vscode icons so not really sure. 



Signed-off-by: vishnu-buildd <vishnu@buildd.in>