### PR TITLE
Extended support for LiveView (`*.heex`)

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -785,6 +785,7 @@
 		"exs": "_f_elixir",
 		"eex": "_f_elixir",
 		"leex": "_f_elixir",
+		"heex": "_f_elixir",
 		"elm": "_f_elm",
 		"erl": "_f_erlang",
 		"hrl": "_f_erlang",


### PR DESCRIPTION
Hello,

I have been using this icon pack for a while now. Thanks for the extension 🙏 

LiveView has added support for another file extension `.heex`. This PR simply adds the same icon as `.leex` files.

This is my first attempt at some sort of open source contribution. Not sure if I am doing it correctly.

Anyway, would love to have support for this file on a future version of this extension 💪 