### PR TITLE
Add missing icon definition for makefile

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -123,6 +123,7 @@
 		"_f_sass": { "iconPath": "./icons/sass.svg" },
 		"_f_scala": { "iconPath": "./icons/scala.svg" },
 		"_f_settings": { "iconPath": "./icons/settings.svg" },
+		"_f_settings-red": { "iconPath": "./icons/settings-red.svg" },
 		"_f_shell": { "iconPath": "./icons/shell.png" },
 		"_f_slim": { "iconPath": "./icons/slim.svg" },
 		"_f_source": { "iconPath": "./icons/source.svg" },


### PR DESCRIPTION
A new icon for makefile was added in https://github.com/EmmanuelBeziat/vscode-great-icons/commit/92aa4daf10a3690ad162345e91f04b980668af3e, but the icon definition it refers to was missing.